### PR TITLE
Add Dockerfile for Frontend 

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm i
+
+CMD ["npm","run","dev"]
+
+EXPOSE 3000

--- a/frontend/Dockerignore
+++ b/frontend/Dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
This PR adds a `Dockerfile` to containerize the frontend application for consistent development or deployment across different environments. The setup focuses solely on the frontend and intentionally excludes any backend or database integration.

 ✅ Key Highlights

- Added a **Dockerfile** for the frontend application.
- Designed to run the app inside a Docker container using the standard `npm run dev` command.
- Exposes the appropriate frontend development port (`3000` by default).
- Keeps the setup **backend-agnostic**, allowing frontend and backend to be developed or deployed independently.