### PR TITLE
Using DockerHub images instead of building locally

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,7 @@ services:
       - app-network
 
   backend:
-    build:
-      context: ./backend
+    image: ashankguptaa/blogwave-backend
     container_name: backend
     ports:
       - "3001:3001"
@@ -26,8 +25,7 @@ services:
       - app-network
 
   frontend:
-    build:
-      context: ./frontend
+    image: ashankguptaa/blogwave-frontend
     container_name: frontend
     ports:
       - "3000:3000"  


### PR DESCRIPTION
Summary
- Replaced local docker image builds with pre-built images from Dockerhub.
-  Backend : ashankguptaa/blogwave-backend.
- Frontend: ashankguptaa/blogwave-frontend.
- Simplifies deployment process by eliminating the build step.